### PR TITLE
Add support for multi-word search queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/__pycache__/*
 discord.log
+.secrets
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__/*
+discord.log

--- a/main.py
+++ b/main.py
@@ -1,0 +1,38 @@
+import discord
+from discord.ext import commands
+from discord.ext.commands.bot import when_mentioned_or
+
+import os
+import logging
+
+# Import cogs
+from yamb.cogs.music import Music
+
+description = '''
+Yet another music bot.
+Powered by OSDG@IIITH.
+Contribute at https://github.com/OSDG-IIITH/yamb.
+'''
+
+def main():
+    # Logging
+    logger = logging.getLogger('discord')
+    logger.setLevel(logging.DEBUG)
+    handler = logging.FileHandler(filename='discord.log', encoding='utf-8', mode='w')
+    handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+    logger.addHandler(handler)
+    
+    # Bot Setup
+    bot = commands.Bot(command_prefix=when_mentioned_or('?'), description=description)
+
+    @bot.event
+    async def on_ready():
+        print(f'Logged in as {bot.user.name}#{bot.user.discriminator}')
+    
+    token = os.environ.get('BOT_TOKEN')
+    bot.add_cog(Music(bot))
+    bot.run(token)
+
+if __name__ == '__main__':
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+aiohttp==3.7.4.post0
+async-timeout==3.0.1
+attrs==21.2.0
+cffi==1.14.6
+chardet==4.0.0
+discord.py==1.7.3
+idna==3.2
+multidict==5.1.0
+pycparser==2.20
+PyNaCl==1.4.0
+six==1.16.0
+typing-extensions==3.10.0.0
+yarl==1.6.3
+youtube-dl==2021.6.6

--- a/yamb/cogs/music.py
+++ b/yamb/cogs/music.py
@@ -56,20 +56,11 @@ class Music(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    # @commands.command()
-    # async def join(self, ctx, *, channel: discord.VoiceChannel):
-    #     """Joins a voice channel"""
-
-    #     if ctx.voice_client is not None:
-    #         return await ctx.voice_client.move_to(channel)
-
-    #     await channel.connect()
-
-
     @commands.command()
-    async def play(self, ctx, *, url):
-        """Plays music from url"""
+    async def play(self, ctx, *args):
+        """Plays music from query"""
 
+        url = ' '.join(args)
         async with ctx.typing():
             player = await YTDLSource.from_url(url, loop=self.bot.loop, stream=True)
             ctx.voice_client.play(player, after=lambda e: print('Player error: %s' % e) if e else None)

--- a/yamb/cogs/music.py
+++ b/yamb/cogs/music.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import discord
+import youtube_dl
+
+from discord.ext import commands
+
+# Suppress noise about console usage from errors
+youtube_dl.utils.bug_reports_message = lambda: ''
+
+
+ytdl_format_options = {
+    'format': 'bestaudio/best',
+    'outtmpl': '%(extractor)s-%(id)s-%(title)s.%(ext)s',
+    'restrictfilenames': True,
+    'noplaylist': True,
+    'nocheckcertificate': True,
+    'ignoreerrors': False,
+    'logtostderr': False,
+    'quiet': True,
+    'no_warnings': True,
+    'default_search': 'auto',
+    'source_address': '0.0.0.0' # bind to ipv4 since ipv6 addresses cause issues sometimes
+}
+
+ffmpeg_options = {
+    'options': '-vn'
+}
+
+ytdl = youtube_dl.YoutubeDL(ytdl_format_options)
+
+
+class YTDLSource(discord.PCMVolumeTransformer):
+    def __init__(self, source, *, data, volume=0.5):
+        super().__init__(source, volume)
+
+        self.data = data
+
+        self.title = data.get('title')
+        self.url = data.get('url')
+
+    @classmethod
+    async def from_url(cls, url, *, loop=None, stream=False):
+        loop = loop or asyncio.get_event_loop()
+        data = await loop.run_in_executor(None, lambda: ytdl.extract_info(url, download=not stream))
+
+        if 'entries' in data:
+            # take first item from a playlist
+            data = data['entries'][0]
+
+        filename = data['url'] if stream else ytdl.prepare_filename(data)
+        return cls(discord.FFmpegPCMAudio(filename, **ffmpeg_options), data=data)
+
+
+class Music(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    # @commands.command()
+    # async def join(self, ctx, *, channel: discord.VoiceChannel):
+    #     """Joins a voice channel"""
+
+    #     if ctx.voice_client is not None:
+    #         return await ctx.voice_client.move_to(channel)
+
+    #     await channel.connect()
+
+
+    @commands.command()
+    async def play(self, ctx, *, url):
+        """Streams from a url (same as yt, but doesn't predownload)"""
+
+        async with ctx.typing():
+            player = await YTDLSource.from_url(url, loop=self.bot.loop, stream=True)
+            ctx.voice_client.play(player, after=lambda e: print('Player error: %s' % e) if e else None)
+
+        await ctx.send('Now playing: {}'.format(player.title))
+
+    @commands.command()
+    async def volume(self, ctx, volume: int):
+        """Changes the player's volume"""
+
+        if ctx.voice_client is None:
+            return await ctx.send("Not connected to a voice channel.")
+
+        ctx.voice_client.source.volume = volume / 100
+        await ctx.send("Changed volume to {}%".format(volume))
+
+    @commands.command()
+    async def stop(self, ctx):
+        """Stops and disconnects the bot from voice"""
+
+        await ctx.voice_client.disconnect()
+
+    @play.before_invoke
+    async def ensure_voice(self, ctx):
+        if ctx.voice_client is None:
+            if ctx.author.voice:
+                await ctx.author.voice.channel.connect()
+            else:
+                await ctx.send("You are not connected to a voice channel.")
+                raise commands.CommandError("Author not connected to a voice channel.")
+        elif ctx.voice_client.is_playing():
+            ctx.voice_client.stop()
+
+
+

--- a/yamb/cogs/music.py
+++ b/yamb/cogs/music.py
@@ -68,7 +68,7 @@ class Music(commands.Cog):
 
     @commands.command()
     async def play(self, ctx, *, url):
-        """Streams from a url (same as yt, but doesn't predownload)"""
+        """Plays music from url"""
 
         async with ctx.typing():
             player = await YTDLSource.from_url(url, loop=self.bot.loop, stream=True)


### PR DESCRIPTION
Previously, the ytdl backend would perform a search only using the first argument taken from the `?play` command.
This commit introduces changes to allow multi-word search queries, and also removes some dead code.